### PR TITLE
Do not forcefully exit before clean-up is done

### DIFF
--- a/cmd/dataplaneapi/main.go
+++ b/cmd/dataplaneapi/main.go
@@ -223,7 +223,6 @@ func startServer(cfg *configuration.Configuration) (reload configuration.AtomicB
 			if err != nil {
 				log.Fatalf("Error shutting down HAProxy Data Plane API: %s", err.Error())
 			}
-			os.Exit(0)
 		case <-dataplaneapi.ContextHandler.Context().Done():
 			return
 		}

--- a/e2e/libs/resource_client.bash
+++ b/e2e/libs/resource_client.bash
@@ -39,7 +39,7 @@ function resource_delete() {
   local endpoint;  endpoint="$1"; shift
 	local qs_params; qs_params="$1"
 
-	run dpa_curl DELETE "$endpoint?$qs_params&version=$(version)" "$data"
+	run dpa_curl DELETE "$endpoint?$qs_params&version=$(version)"
 	assert_success
 	dpa_curl_status_body '$output'
 }


### PR DESCRIPTION
Shut down of the various enabled servers is performed at `Server.handleShutdown()`. This function runs right after the signals are captured and `Server.Shutdown()` is called.

If `exit()` is called right after the shutdown channel is released, there is a very high chance that `handleShutdown()` cannot run (net/http) `Server.Shutdown()` in order to gracefully release the held resources before the main thread exits.

All the 453 tests passed (`make e2e` locally run).